### PR TITLE
Basic loadLAS unit test

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -11,9 +11,13 @@ module.exports = {
 	//// Loads a LAS 2.0 file from local files
 	loadLAS:function(well_log){
 		var file = well_log
-		var contents = fs.readFileSync(file).toString();
-		// var contents = fs.readFileSync('test.LAS', 'utf8');
-		return contents
+    var fs = '';
+    if (!process.env.BROWER) {
+       fs = require('fs');
+    }
+    var contents = fs.readFileSync(file).toString();
+    // var contents = fs.readFileSync('test.LAS', 'utf8');
+    return contents
 	},
 	//// Converts a LAS 2.0 file already loaded into memory into a json format
 	las2json: function(onelas){

--- a/dist/index.js
+++ b/dist/index.js
@@ -12,7 +12,8 @@ module.exports = {
 	loadLAS:function(well_log){
 		var file = well_log
     var fs = '';
-    if (!process.env.BROWER) {
+
+    if (process !== 'undefined' && process.versions != null && process.versions.node != null) {
        fs = require('fs');
     }
     var contents = fs.readFileSync(file).toString();

--- a/dist/test/test_lasload.js
+++ b/dist/test/test_lasload.js
@@ -1,0 +1,58 @@
+var test = require('tape');
+const wellio = require('../index.js');
+
+test('LASloaded file matches expected string', function (t) {
+  t.plan(1);
+
+  let test_str = `~VERSION INFORMATION
+ VERS.                          2.0 :   CWLS LOG ASCII STANDARD -VERSION 2.0
+ WRAP.                          NO  :   ONE LINE PER DEPTH STEP
+~WELL INFORMATION 
+#MNEM.UNIT              DATA                       DESCRIPTION
+#----- -----            ----------               -------------------------
+STRT    .M              1670.0000                :START DEPTH
+STOP    .M              1660.0000                :STOP DEPTH
+STEP    .M              -0.1250                  :STEP 
+NULL    .               -999.25                  :NULL VALUE
+COMP    .       ANY OIL COMPANY INC.             :COMPANY
+WELL    .       AAAAA_2            :WELL
+FLD     .       WILDCAT                          :FIELD
+LOC     .       12-34-12-34W5M                   :LOCATION
+PROV    .       ALBERTA                          :PROVINCE 
+SRVC    .       ANY LOGGING COMPANY INC.         :SERVICE COMPANY
+DATE    .       13-DEC-86                        :LOG DATE
+UWI     .       100123401234W500                 :UNIQUE WELL ID
+~CURVE INFORMATION
+#MNEM.UNIT              API CODES                   CURVE DESCRIPTION
+#------------------     ------------              -------------------------
+ DEPT   .M                                       :  1  DEPTH
+ DT     .US/M           60 520 32 00             :  2  SONIC TRANSIT TIME
+ RHOB   .K/M3           45 350 01 00             :  3  BULK DENSITY
+ NPHI   .V/V            42 890 00 00             :  4  NEUTRON POROSITY
+ SFLU   .OHMM           07 220 04 00             :  5  SHALLOW RESISTIVITY
+ SFLA   .OHMM           07 222 01 00             :  6  SHALLOW RESISTIVITY
+ ILM    .OHMM           07 120 44 00             :  7  MEDIUM RESISTIVITY
+ ILD    .OHMM           07 120 46 00             :  8  DEEP RESISTIVITY
+~PARAMETER INFORMATION
+#MNEM.UNIT              VALUE             DESCRIPTION
+#--------------     ----------------      -----------------------------------------------
+ MUD    .               GEL CHEM        :   MUD TYPE
+ BHT    .DEGC           35.5000         :   BOTTOM HOLE TEMPERATURE
+ BS     .MM             200.0000        :   BIT SIZE
+ FD     .K/M3           1000.0000       :   FLUID DENSITY
+ MATR   .               SAND            :   NEUTRON MATRIX
+ MDEN   .               2710.0000       :   LOGGING MATRIX DENSITY
+ RMF    .OHMM           0.2160          :   MUD FILTRATE RESISTIVITY
+ DFD    .K/M3           1525.0000       :   DRILL FLUID DENSITY
+~OTHER
+     Note: The logging tools became stuck at 625 metres causing the data 
+     between 625 metres and 615 metres to be invalid.
+~A  DEPTH     DT    RHOB        NPHI   SFLU    SFLA      ILM      ILD
+1670.000   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.875   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.750   123.450 2550.000    0.450  123.450  123.450  110.200  105.600`;
+  
+  let well_string = wellio.loadLAS("assets/lasio_test.LAS");
+
+  t.equal(well_string === test_str, true);
+});

--- a/package.json
+++ b/package.json
@@ -5,12 +5,14 @@
   "main": "dist/index.js",
   "unpkg": "dist/index.js",
   "scripts": {
-    "test": "dist/test/test.js"
+    "test": "dist/test/test.js",
+    "test-lasload": "node dist/test/test_lasload.js"
   },
   "files": [
+    "dist/index.js",
     "dist/test/test.js",
     "dist/test/test.LAS",
-    "dist/index.js"
+    "dist/test/test_lasload.js"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
@JustinGOSSES,

This change implements a simple initial unit test for loadLAS() in dist/index.js. 
- It checks for node environment and requires the 'fs' module if in node so it can read the las file.
- It uses the assets/lassio_test.LAS.  This looked like a complete but short example.  I didn't move or copy it into the dist/test/ directory.  Let me know if you want test las files in a certain directory path.    
- It adds a node script to package.json to run the test with `npm run test-lasload`

Let me know if this change could be accepted (or rejected) or needs some additional changes before merging.

Thanks,

DC