### PR TITLE
Proposed fix for issue #20 test with blank_line.las

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -174,33 +174,27 @@ module.exports = {
 				console.log("elem: [" + well_line_array[i] + "]");
 			}
 		}
-		//// Working with CURVES second by splitting it by newline into an array,
-		//// then using the first line item of that array to find the curve names
-		//// using those curves names to establish object keys and then interating through the other array items
-		//// and populating arrays for each key
+		//// Work with CURVES section by splitting it by newline into an array,
+		//// Interate through the array items populate arrays for each key
 		var curve_str_array = curve_str.split("\n");
-		var curve_names_array = [];
-		var curve_names_array_holder = [];
-		curve_names_array = curve_str_array[0].split(" ")
 
-		//// If there are curve names, push them into the curve_names_array_holder
-		//// and intialize the curve key in CURVES
-		if(curve_names_array.length > 1){
-			var last_curv_name_position = curve_names_array.length - 1;
-			curve_names_array[last_curv_name_position] = curve_names_array[last_curv_name_position].replace("\r","")
-			console.log("0 curve_names_array = ",curve_names_array)
-			curve_names_array = curve_names_array.slice(1,curve_names_array.length);
-			for(i = 0; i < curve_names_array.length; i++){
-				if(curve_names_array[i] !== ""){
-					console.log("0.5 curve_names_array[i] = ",curve_names_array[i])
-					curve_names_array_holder.push(curve_names_array[i]);
-					lasjson["CURVES"][curve_names_array[i]] = []
-				}
-			}
-		}
-		else{
-			console.log("INFO: Couldn't find curve names above curves in LAS, check formatting!");
-		}
+    //// Get the curve column names from the curve names in the curve information block
+    ////
+    //// Per LAS_20_Update_Jan2014.pdf section 5.5 specs for ~C(Curve Information)
+    //// - This section is manditory.
+    //// - It desribes the curves and its units in the order they appear in the ~ASCII
+    ////   log data section of the file.
+    //// - The channels described in this section must be present in the data set.
+		var curve_names_array_holder = [];
+    var curve_info = Object.keys(lasjson['CURVE INFORMATION BLOCK']);
+
+    if (curve_info.length > 0){
+      for(k = 0; k < curve_info.length; k++){
+        col_name = curve_info[k];
+        curve_names_array_holder.push(col_name);
+        lasjson.CURVES[col_name] = [];
+      }
+    }
 
 		//// start at position 1 instead of 0 is to avoid the curve names
 		for(j = 1; j < curve_str_array.length; j++){
@@ -217,29 +211,8 @@ module.exports = {
 			var counter_of_curve_names = 0;
 			console.log("curve_data_line_array.length = ",curve_data_line_array.length)
 			console.log("curve_data_line_array = ",curve_data_line_array)
-			//// If we didn't get curve column names from '~A section header then
-			//// get them from get the column names from the curve information block
-			//// else
-			//// build a default set.
-			if (curve_names_array_holder.length === 0){
-				curve_info = Object.keys(lasjson['CURVE INFORMATION BLOCK']);
 
-				if (curve_info.length === curve_data_line_array.length){
-					for(k = 0; k < curve_data_line_array.length; k++){
-						col_name = curve_info[k];
-						curve_names_array_holder.push(col_name);
-						lasjson.CURVES[col_name] = [];
-					}
-				}
-				else {
-					for(k = 0; k < curve_data_line_array.length; k++){
-						num = k + 1;
-						col_name = 'COL' + num;
-						curve_names_array_holder.push(col_name);
-						lasjson.CURVES[col_name] = [];
-					}
-				}
-			}
+
 			var last_curv_data_line_position = curve_data_line_array.length - 1;
 			console.log("curve_data_line_array[last_curv_data_line_position] = ",curve_data_line_array[last_curv_data_line_position])
 			curve_data_line_array[last_curv_data_line_position] = curve_data_line_array[last_curv_data_line_position].replace("\r","")

--- a/dist/index.js
+++ b/dist/index.js
@@ -178,23 +178,23 @@ module.exports = {
 		//// Interate through the array items populate arrays for each key
 		var curve_str_array = curve_str.split("\n");
 
-    //// Get the curve column names from the curve names in the curve information block
-    ////
-    //// Per LAS_20_Update_Jan2014.pdf section 5.5 specs for ~C(Curve Information)
-    //// - This section is manditory.
-    //// - It desribes the curves and its units in the order they appear in the ~ASCII
-    ////   log data section of the file.
-    //// - The channels described in this section must be present in the data set.
+		//// Get the curve column names from the curve names in the curve information block
+		////
+		//// Per LAS_20_Update_Jan2014.pdf section 5.5 specs for ~C(Curve Information)
+		//// - This section is manditory.
+		//// - It desribes the curves and its units in the order they appear in the ~ASCII
+		////	 log data section of the file.
+		//// - The channels described in this section must be present in the data set.
 		var curve_names_array_holder = [];
-    var curve_info = Object.keys(lasjson['CURVE INFORMATION BLOCK']);
+		var curve_info = Object.keys(lasjson['CURVE INFORMATION BLOCK']);
 
-    if (curve_info.length > 0){
-      for(k = 0; k < curve_info.length; k++){
-        col_name = curve_info[k];
-        curve_names_array_holder.push(col_name);
-        lasjson.CURVES[col_name] = [];
-      }
-    }
+		if (curve_info.length > 0){
+			for(k = 0; k < curve_info.length; k++){
+				col_name = curve_info[k];
+				curve_names_array_holder.push(col_name);
+				lasjson.CURVES[col_name] = [];
+			}
+		}
 
 		//// start at position 1 instead of 0 is to avoid the curve names
 		for(j = 1; j < curve_str_array.length; j++){

--- a/dist/test/las2json/test_blank_line_in_header.js
+++ b/dist/test/las2json/test_blank_line_in_header.js
@@ -2,7 +2,7 @@ const test = require('tape');
 const wellio = require('../../index.js');
 
 // TODO: Fix: [TypeError: Cannot read property 'trim' of undefined] 
-test.skip('las2json: test_blank_line_in_header', function(t) {
+test('las2json: test_blank_line_in_header', function(t) {
   t.plan(2);
   let well_string = wellio.loadLAS("assets/blank_line.las");
 
@@ -11,5 +11,5 @@ test.skip('las2json: test_blank_line_in_header', function(t) {
   });
 
   let well_json = wellio.las2json(well_string);
-  t.equal(well_json.curves[0] === "DEPT");
+  t.ok('DEPT' in well_json.CURVES, "'DEPT' curve header is in CURVES");
 });


### PR DESCRIPTION
@JustinGOSSES,

This is a proposed fix for issue #20 test with blank_line.las.  It passes  'test-all' and 'test-las2json.

The change refactors building curve headers per 2.0 spec. The LAS_20_Update_Jan2014.pdf of the LAS specifications says the ~CURVE INFORMATION section must have curves (curve names) in the order they (the data columns) appear in the ~ASCII log data section.  Given that interpretation, I removed the other options for building the Curve name array and just rely on getting the names from the CURVE INFORMATION BLOCK.

Reference:
http://www.cwls.org/wp-content/uploads/2014/09/LAS_20_Update_Jan2014.pdf
https://github.com/kinverarity1/lasio/blob/master/standards/LAS_20_Update_Jan2014.pdf

If it is desirable to have the fall back options of getting the names from the ~ASCII section (if they are there) and lastly generating a set of generic column headers, let me know and I'll add them back in. 

Let me know if this change could be accepted (or rejected) or needs some additional changes before merging.

Thanks,

DC