### PR TITLE
Enable test for missing ~A section data.

### DIFF
--- a/dist/test/las2json/test_missing_a_section.js
+++ b/dist/test/las2json/test_missing_a_section.js
@@ -1,9 +1,8 @@
 const test = require('tape');
 const wellio = require('../../index.js');
 
-// TODO: Fix: [TypeError: Cannot read property 'trim' of undefined]
-test.skip('las2json: test_missing_a_section', function(t) {
-  t.plan(2);
+test('las2json: test_missing_a_section', function(t) {
+  t.plan(4);
   let well_string = wellio.loadLAS("assets/missing_a_section.las");
 
   t.doesNotThrow(function() {
@@ -11,6 +10,15 @@ test.skip('las2json: test_missing_a_section', function(t) {
   });
 
   let well_json = wellio.las2json(well_string);
-  // TODO: change to check that well_json.CURVES is empty
-  t.ok('data' in well_json, false);
+  t.equal(Object.keys(well_json.CURVES).length, 1,
+    'Missing data test: well_json.CURVES has one key'
+  );
+
+  t.ok('DEPT' in well_json.CURVES,
+    'Missing data test: "DEPT" MNEM is the key well_json.CURVES'
+  );
+
+  t.equal(well_json.CURVES.DEPT.length, 0,
+    'Missing data test: well_json_CURVES.DEPT has no data'
+  );
 });


### PR DESCRIPTION
@JustinGOSSES,

The purpose of this test is to validate that wellio.js doesn't crash or
panic when the ~A section has no data. It fixes issue #22 .

The test code was fixed to check the status of the internal data
representation for the CURVES (~A) section.  No changes were needed to
the main wellio.js code.

Let me know if this needs some additional changes before merging.  

Thanks,

DC
