### PR TITLE
Issue 12: Handle wrapped data properly

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -175,7 +175,7 @@ module.exports = {
 			}
 		}
 		//// Work with CURVES section by splitting it by newline into an array,
-		//// Interate through the array items populate arrays for each key
+		//// Iterate through the array items populate arrays for each key
 		var curve_str_array = curve_str.split("\n");
 
 		//// Get the curve column names from the curve names in the curve information block
@@ -196,18 +196,36 @@ module.exports = {
 			}
 		}
 
+		var curve_data_line_array = [];
+
 		//// start at position 1 instead of 0 is to avoid the curve names
 		for(j = 1; j < curve_str_array.length; j++){
 			//// Skip empty rows.
 			if (curve_str_array[j].length === 0) {
 				continue;
 			}
-			var curve_data_line_array = curve_str_array[j].split(/\s+/);
 
+			var temp_data_array = curve_str_array[j].split(/\s+/);
 			//// Split can leave an empty element at the beginning, remove it.
-			if (curve_data_line_array[0].length === 0){
-				curve_data_line_array.shift();
+			if (temp_data_array[0].length === 0){
+				temp_data_array.shift();
 			}
+
+			//// If data is wrapped continue to accumulate data from rows till
+			//// we have a data element for each data column
+			var idx = curve_data_line_array.length;
+			curve_data_line_array.length = idx + temp_data_array.length;
+			for (var i = 0; i < temp_data_array.length; i++, idx++) {
+				curve_data_line_array[idx] = temp_data_array[i];
+			}
+
+			if (
+				lasjson["VERSION INFORMATION"].WRAP.DATA == 'YES'
+				&& curve_data_line_array.length < curve_names_array_holder.length)
+			{
+				continue;
+			}
+
 			var counter_of_curve_names = 0;
 			console.log("curve_data_line_array.length = ",curve_data_line_array.length)
 			console.log("curve_data_line_array = ",curve_data_line_array)
@@ -223,6 +241,8 @@ module.exports = {
 					counter_of_curve_names += 1;
 				}
 			}
+			//// Zero out curve_data_line_array for next set of data
+			curve_data_line_array = [];
 		}
 		console.log(" test: lasjson",lasjson);
 		return(lasjson)

--- a/dist/test/las2json/test_read_v2_sample.js
+++ b/dist/test/las2json/test_read_v2_sample.js
@@ -2,10 +2,21 @@ const test = require('tape');
 const wellio = require('../../index.js');
 
 test('las2json: test_read_v2_sample', function(t) {
-  t.plan(1);
+  t.plan(3);
   let well_string = wellio.loadLAS("assets/lasio_test.LAS");
 
   t.doesNotThrow(function() {
     let well_json = wellio.las2json(well_string);
   });
+
+  let well_json = wellio.las2json(well_string);
+  t.equal(well_json.CURVES.DEPT[1], '1669.875',
+    'Read basic sample: 2nd DEPT is 1669.875'
+  );
+
+  ild_len = well_json.CURVES.ILD.length - 1;
+  t.equal(well_json.CURVES.ILD[ild_len], '105.600',
+    'Read basic sample: last ILD is 105.600'
+  );
+  t.end();
 });

--- a/dist/test/las2json/test_read_v2_sample_wrapped.js
+++ b/dist/test/las2json/test_read_v2_sample_wrapped.js
@@ -1,11 +1,28 @@
 const test = require('tape');
 const wellio = require('../../index.js');
 
-test.skip('las2json: test_read_v2_sample_wrapped', function(t) {
-  t.plan(1);
+test('las2json: test_read_v2_sample_wrapped', function(t) {
+  t.plan(4);
   let well_string = wellio.loadLAS("assets/sample_2.0_wrapped.las");
 
   t.doesNotThrow(function() {
     let well_json = wellio.las2json(well_string);
   });
+
+  let well_json = wellio.las2json(well_string);
+
+  console.log(well_json.CURVES.length);
+  console.log(well_json.CURVES);
+  t.equal(well_json.CURVES.DEPT[0], '910.000000',
+    'Wrapped data: 1st DEPT is 910.000000'
+  );
+  t.equal(well_json.CURVES.DEPT[1], '909.875000',
+    'Wrapped data: 2nd DEPT is 909.875000'
+  );
+
+  t.equal(well_json.CURVES.RESD[0], '12.2681',
+    'Wrapped data: 1st RESD is 12.2681'
+  );
+  
+  t.end();
 });


### PR DESCRIPTION
This pull request is a proposed fix for #12 

This change checks if the data is wrapped. If the data is wrapped,
then data elements will be accumulated till we have the same
number of data elements as columns/curve names from the 'CURVE INFORMATION BLOCK'.
This should insure that we have the right number of data elements per
'row'.  The logic makes the assumption that date elements from sequential sets of data rows from the las file will equal the number of columns/curve names from the 'CURVE INFORMATION BLOCK'.  If we find a las file where this is not true, we can change the logic to handle the new case.

This change removes 'skip' from the wrapped data test.
This test now passes and the full test suite was also run and still passes.

Let me know if this needs some additional changes before merging.

Thanks,

DC