### PR TITLE
Add read json tests to github workflow

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -22,6 +22,7 @@ jobs:
         npm ci
         npm run build --if-present
         npm run test-las2json
+        npm run test-read-lasio-json
         npm run test-all
       env:
         CI: true


### PR DESCRIPTION
This is a minor change to add 'npm run test-read-lasio-json' to the .github/workflows/nodejs.yml.

Not entirely sure this is desired and I'm not sure how to test it.  I figured I'd post it so you would have the option to accept or reject.

Thanks,
DC