### PR TITLE
Issue 39: Split read_json function to two parts

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -5,21 +5,37 @@
 module.exports = {
 
   // Read and transform Lasio Json files to Wellio.js json data format
+
 /**
-* The read_json function reads and transforms lasio style JSOn files into wellio.js style JSON data format in memory and returns it.
-* @param {string} lasiojsonfile A string reprepresentatiion of filename of well log in a .json file to be loaded into memory and converted from lasio to wellio style JSON
-* @returns {object} A wellio style JSON object
-*/
-  read_json: function(lasiojsonfile) {
+ * File reading utility function.
+ * @param {string} : file_to_read - The file to open.
+ *
+ * @returns {string} : The file's contents as a string.
+ */
+  read_file: function(file_to_read) {
     // Configure fs if running from node
-    // TODO: implement how to handle when fs is not available.
-    var fs = '';
+    let fs = '';
 
     if (process !== 'undefined' && process.versions != null && process.versions.node != null) {
        fs = require('fs');
     }
 
-    let lj = JSON.parse(fs.readFileSync(lasiojsonfile, 'utf8'));
+    return fs.readFileSync(file_to_read, 'utf8');
+  },
+
+/**
+* The lasio_2_wellio function transforms lasio JSON strings into wellio.js JSON data format in memory and returns it.
+* @param {object} lasio_json - A JavaScript object representation of lasio well log format
+*
+* @example
+* let wellio = require('wellio')
+* let lasio_json_str = wellio.read_file('lasio.json');
+* let lasio_obj = JSON.parse(lasio_json_str);
+* let wellio_obj = wellio.lasio_2_wellio(lasio_obj);
+*
+* @returns {object} A wellio style JSON object
+*/
+  lasio_2_wellio: function(lasio_obj) {
 
     let std_headers = {
       'Version': 'VERSION INFORMATION',
@@ -33,20 +49,20 @@ module.exports = {
 		lasjson["WELL INFORMATION BLOCK"] = {};
 		lasjson["CURVE INFORMATION BLOCK"] = {};
 		lasjson["PARAMETER INFORMATION"] = {};
-		lasjson["CURVES"] = lj.data;
+		lasjson["CURVES"] = lasio_obj.data;
 
     // Example code for adding non-standard headers
-    for (let item in lj.metadata) {
+    for (let item in lasio_obj.metadata) {
       if ( !(item in std_headers) ) {
-        lasjson[item.toUpperCase()] = lj.metadata[item];
+        lasjson[item.toUpperCase()] = lasio_obj.metadata[item];
       }
       else {
-        for (let mnemonic in lj.metadata[item]) {
+        for (let mnemonic in lasio_obj.metadata[item]) {
           section = std_headers[item];      
           lasjson[section][mnemonic] = {
             MNEM: mnemonic,
             UNIT: '',
-            DATA: lj.metadata[item][mnemonic],
+            DATA: lasio_obj.metadata[item][mnemonic],
             'DESCRIPTION OF MNEMONIC 1': '',
             'DESCRIPTION OF MNEMONIC 2': ''
           };
@@ -61,7 +77,7 @@ module.exports = {
 /**
  * A helper function that proves wellio,js was installed correctly. It merely returns the argument provided to it. For example, "test" as input would return "test".
  * @param {*} onelas anything
- * @returns Returens the input that was givne as an argument. This is just for testing that wellio was installed correctly.
+ * @returns Returns the input that was givne as an argument. This is just for testing that wellio was installed correctly.
  * @example wellio.returnThing("test") = "test"
  */
 	returnThing: function(onelas){

--- a/dist/index.js
+++ b/dist/index.js
@@ -24,18 +24,18 @@ module.exports = {
   },
 
 /**
-* The lasio_2_wellio function transforms lasio JSON strings into wellio.js JSON data format in memory and returns it.
+* The lasio_obj_2_wellio_obj function transforms lasio JSON strings into wellio.js JSON data format in memory and returns it.
 * @param {object} lasio_json - A JavaScript object representation of lasio well log format
 *
 * @example
 * let wellio = require('wellio')
 * let lasio_json_str = wellio.read_file('lasio.json');
 * let lasio_obj = JSON.parse(lasio_json_str);
-* let wellio_obj = wellio.lasio_2_wellio(lasio_obj);
+* let wellio_obj = wellio.lasio_obj_2_wellio_obj(lasio_obj);
 *
 * @returns {object} A wellio style JSON object
 */
-  lasio_2_wellio: function(lasio_obj) {
+  lasio_obj_2_wellio_obj: function(lasio_obj) {
 
     let std_headers = {
       'Version': 'VERSION INFORMATION',

--- a/dist/index.js
+++ b/dist/index.js
@@ -12,7 +12,7 @@ module.exports = {
  *
  * @returns {string} : The file's contents as a string.
  */
-  read_file: function(file_to_read) {
+  read_lasio_json_file: function(file_to_read) {
     // Configure fs if running from node
     let fs = '';
 
@@ -29,7 +29,7 @@ module.exports = {
 *
 * @example
 * let wellio = require('wellio')
-* let lasio_json_str = wellio.read_file('lasio.json');
+* let lasio_json_str = wellio.read_lasio_json_file('lasio.json');
 * let lasio_obj = JSON.parse(lasio_json_str);
 * let wellio_obj = wellio.lasio_obj_2_wellio_obj(lasio_obj);
 *

--- a/dist/test/read_las_json/test_read_v2_sample.js
+++ b/dist/test/read_las_json/test_read_v2_sample.js
@@ -6,10 +6,10 @@ test('readLasioJson: test_read_v2_sample', function(t) {
   json_file = "assets/json_files/sample_2.0.json";
 
   t.doesNotThrow(function() {
-    let lasio_json_str = wellio.read_file(json_file);
+    let lasio_json_str = wellio.read_lasio_json_file(json_file);
   });
 
-  let lasio_json_str = wellio.read_file(json_file);
+  let lasio_json_str = wellio.read_lasio_json_file(json_file);
   let lasio_obj = JSON.parse(lasio_json_str);
   let wellio_obj = wellio.lasio_obj_2_wellio_obj(lasio_obj);
 

--- a/dist/test/read_las_json/test_read_v2_sample.js
+++ b/dist/test/read_las_json/test_read_v2_sample.js
@@ -6,12 +6,14 @@ test('readLasioJson: test_read_v2_sample', function(t) {
   json_file = "assets/json_files/sample_2.0.json";
 
   t.doesNotThrow(function() {
-    let well_json = wellio.read_json(json_file);
+    let lasio_json_str = wellio.read_file(json_file);
   });
 
-  let well_json = wellio.read_json(json_file);
+  let lasio_json_str = wellio.read_file(json_file);
+  let lasio_obj = JSON.parse(lasio_json_str);
+  let wellio_obj = wellio.lasio_2_wellio(lasio_obj);
 
-  t.equal(well_json["VERSION INFORMATION"].VERS.DATA, 2,
+  t.equal(wellio_obj["VERSION INFORMATION"].VERS.DATA, 2,
     "Sample json: LAS is version 2"
   );
 

--- a/dist/test/read_las_json/test_read_v2_sample.js
+++ b/dist/test/read_las_json/test_read_v2_sample.js
@@ -11,7 +11,7 @@ test('readLasioJson: test_read_v2_sample', function(t) {
 
   let lasio_json_str = wellio.read_file(json_file);
   let lasio_obj = JSON.parse(lasio_json_str);
-  let wellio_obj = wellio.lasio_2_wellio(lasio_obj);
+  let wellio_obj = wellio.lasio_obj_2_wellio_obj(lasio_obj);
 
   t.equal(wellio_obj["VERSION INFORMATION"].VERS.DATA, 2,
     "Sample json: LAS is version 2"

--- a/dist/test/read_las_json/test_read_v2_sample_empty_headers.js
+++ b/dist/test/read_las_json/test_read_v2_sample_empty_headers.js
@@ -9,12 +9,14 @@ test('readLasioJson: test_read_v2_sample_empty_headers', function(t) {
   json_file = "assets/json_files/sample_2.0_empty_headers.json";
 
   t.doesNotThrow(function() {
-    let well_json = wellio.read_json(json_file);
+    let lasio_json_str = wellio.read_file(json_file);
   });
 
-  let well_json = wellio.read_json(json_file);
+  let lasio_json_str = wellio.read_file(json_file);
+  let lasio_obj = JSON.parse(lasio_json_str);
+  let wellio_obj = wellio.lasio_2_wellio(lasio_obj);
 
-  t.false('VERS' in well_json["VERSION INFORMATION"],
+  t.false('VERS' in wellio_obj["VERSION INFORMATION"],
     "Sample json, empty headers: 'VERS' key is not in the Version section"
   );
 

--- a/dist/test/read_las_json/test_read_v2_sample_empty_headers.js
+++ b/dist/test/read_las_json/test_read_v2_sample_empty_headers.js
@@ -9,10 +9,10 @@ test('readLasioJson: test_read_v2_sample_empty_headers', function(t) {
   json_file = "assets/json_files/sample_2.0_empty_headers.json";
 
   t.doesNotThrow(function() {
-    let lasio_json_str = wellio.read_file(json_file);
+    let lasio_json_str = wellio.read_lasio_json_file(json_file);
   });
 
-  let lasio_json_str = wellio.read_file(json_file);
+  let lasio_json_str = wellio.read_lasio_json_file(json_file);
   let lasio_obj = JSON.parse(lasio_json_str);
   let wellio_obj = wellio.lasio_obj_2_wellio_obj(lasio_obj);
 

--- a/dist/test/read_las_json/test_read_v2_sample_empty_headers.js
+++ b/dist/test/read_las_json/test_read_v2_sample_empty_headers.js
@@ -14,7 +14,7 @@ test('readLasioJson: test_read_v2_sample_empty_headers', function(t) {
 
   let lasio_json_str = wellio.read_file(json_file);
   let lasio_obj = JSON.parse(lasio_json_str);
-  let wellio_obj = wellio.lasio_2_wellio(lasio_obj);
+  let wellio_obj = wellio.lasio_obj_2_wellio_obj(lasio_obj);
 
   t.false('VERS' in wellio_obj["VERSION INFORMATION"],
     "Sample json, empty headers: 'VERS' key is not in the Version section"

--- a/dist/test/read_las_json/test_read_v2_sample_pretty.js
+++ b/dist/test/read_las_json/test_read_v2_sample_pretty.js
@@ -6,12 +6,14 @@ test('las2json: test_read_v2_sample', function(t) {
   json_file = "assets/json_files/sample_2.0_pretty.json";
 
   t.doesNotThrow(function() {
-    let well_json = wellio.read_json(json_file);
+    let lasio_json_str = wellio.read_file(json_file);
   });
 
-  let well_json = wellio.read_json(json_file);
+  let lasio_json_str = wellio.read_file(json_file);
+  let lasio_obj = JSON.parse(lasio_json_str);
+  let wellio_obj = wellio.lasio_2_wellio(lasio_obj);
 
-  t.equal(well_json["VERSION INFORMATION"].VERS.DATA, 2,
+  t.equal(wellio_obj["VERSION INFORMATION"].VERS.DATA, 2,
     "Sample pretty json: LAS is version 2"
   );
 

--- a/dist/test/read_las_json/test_read_v2_sample_pretty.js
+++ b/dist/test/read_las_json/test_read_v2_sample_pretty.js
@@ -11,7 +11,7 @@ test('las2json: test_read_v2_sample', function(t) {
 
   let lasio_json_str = wellio.read_file(json_file);
   let lasio_obj = JSON.parse(lasio_json_str);
-  let wellio_obj = wellio.lasio_2_wellio(lasio_obj);
+  let wellio_obj = wellio.lasio_obj_2_wellio_obj(lasio_obj);
 
   t.equal(wellio_obj["VERSION INFORMATION"].VERS.DATA, 2,
     "Sample pretty json: LAS is version 2"

--- a/dist/test/read_las_json/test_read_v2_sample_pretty.js
+++ b/dist/test/read_las_json/test_read_v2_sample_pretty.js
@@ -6,10 +6,10 @@ test('las2json: test_read_v2_sample', function(t) {
   json_file = "assets/json_files/sample_2.0_pretty.json";
 
   t.doesNotThrow(function() {
-    let lasio_json_str = wellio.read_file(json_file);
+    let lasio_json_str = wellio.read_lasio_json_file(json_file);
   });
 
-  let lasio_json_str = wellio.read_file(json_file);
+  let lasio_json_str = wellio.read_lasio_json_file(json_file);
   let lasio_obj = JSON.parse(lasio_json_str);
   let wellio_obj = wellio.lasio_obj_2_wellio_obj(lasio_obj);
 


### PR DESCRIPTION
**Separate file reading from the JSON parsing and from translating lasio object to wellio object.**

Resolves #39 

Here is the set of steps that replace wellio.read_file():
- let wellio = require('wellio')
- let lasio_json_str = wellio.read_file('assets/json_files/sample_2.0.json');
- let lasio_obj = JSON.parse(lasio_json_str);
- let wellio_obj = wellio.lasio_2_wellio(lasio_obj);

**Tests**
Tests were changed to use the above steps. All tests pass.
To run the json specific tests:
`npm run test-read-lasio-json`

**Special Note : NaN (Not a Number)**
If a las json file includes NaN elements, then JSON.parse() will throw and error and exit.
This is because 'NaN' is not part the JSON specification. The specification does allow 'null'.


**Wellioviz**
Wellioviz was manually tested manually using the terminal command line.
```node
wellioviz = require('wellioviz');/  
> three_things_2 = wellioviz.fromJSONofWEllGetThingsForPlotting(wellio_obj,"DEPT");
{
  well_log_curves_reformatted_for_d3: [
    {
      UWI: '100123401234W500',
      DEPT: 1670,
      DT: 123.45,
      RHOB: 2550,
      NPHI: 0.45,
      SFLU: 123.45,
      SFLA: 123.45,
      ILM: 110.2,
      ILD: 105.6
    },
    {
      UWI: '100123401234W500',
      DEPT: 1669.875,
      DT: 123.45,
      RHOB: 2550,
      NPHI: 0.45,
      SFLU: 123.45,
      SFLA: 123.45,
      ILM: 110.2,
      ILD: 105.6
    },
    {
      UWI: '100123401234W500',
      DEPT: 1669.75,
      DT: 123.45,
      RHOB: 2550,
      NPHI: 0.45,
      SFLU: 123.45,
      SFLA: 123.45,
      ILM: 110.2,
      ILD: 105.6
    }
  ],
  curve_names: [
    'DEPT', 'DT',
    'RHOB', 'NPHI',
    'SFLU', 'SFLA',
    'ILM',  'ILD'
  ],
  uwi: '100123401234W500'
```

Let me know if this needs some additional changes to get approval for merging.

Thank you!,

DC