### PR TITLE
Fix tests for validating lasio json file reading

### DIFF
--- a/assets/json_files/lasio_sample_2.0_null.json
+++ b/assets/json_files/lasio_sample_2.0_null.json
@@ -1,0 +1,85 @@
+{
+  "metadata": {
+    "Version": {
+      "VERS": 2.0,
+      "WRAP": "NO"
+    },
+    "Well": {
+      "STRT": 1670.0,
+      "STOP": 1660.0,
+      "STEP": -0.125,
+      "NULL": -999.25,
+      "COMP": "ANY OIL COMPANY INC.",
+      "WELL": "AAAAA_2",
+      "FLD": "WILDCAT",
+      "LOC": "12-34-12-34W5M",
+      "PROV": "ALBERTA",
+      "SRVC": "ANY LOGGING COMPANY INC.",
+      "DATE": "13-DEC-86",
+      "UWI": "100123401234W500"
+    },
+    "Curves": {
+      "DEPT": "",
+      "DT": "60 520 32 00",
+      "RHOB": "45 350 01 00",
+      "NPHI": "42 890 00 00",
+      "SFLU": "07 220 04 00",
+      "SFLA": "07 222 01 00",
+      "ILM": "07 120 44 00",
+      "ILD": "07 120 46 00"
+    },
+    "Parameter": {
+      "MUD": "GEL CHEM",
+      "BHT": 35.5,
+      "BS": 200.0,
+      "FD": 1000.0,
+      "MATR": "SAND",
+      "MDEN": 2710.0,
+      "RMF": 0.216,
+      "DFD": 1525.0
+    },
+    "Other": "Note: The logging tools became stuck at 625 metres causing the data\nbetween 625 metres and 615 metres to be invalid."
+  },
+  "data": {
+    "DEPT": [
+      1670.0,
+      1669.875,
+      1669.75
+    ],
+    "DT": [
+      123.45,
+      123.45,
+      123.45
+    ],
+    "RHOB": [
+      2550.0,
+      2550.0,
+      2550.0
+    ],
+    "NPHI": [
+      0.45,
+      0.45,
+      0.45
+    ],
+    "SFLU": [
+      123.45,
+      123.45,
+      123.45
+    ],
+    "SFLA": [
+      123.45,
+      123.45,
+      123.45
+    ],
+    "ILM": [
+      110.2,
+      110.2,
+      110.2
+    ],
+    "ILD": [
+      105.6,
+      null,
+      null
+    ]
+  }
+}

--- a/dist/test/read_las_json/test_read_lasio_sample_2.0.js
+++ b/dist/test/read_las_json/test_read_lasio_sample_2.0.js
@@ -1,0 +1,21 @@
+const test = require('tape');
+const wellio = require('../../index.js');
+
+test('readLasioJson: test_read_sample_2.0.json', function(t) {
+  t.plan(2);
+  json_file = "assets/json_files/lasio_sample_2.0.json";
+
+  t.doesNotThrow(function() {
+    let lasio_json_str = wellio.read_lasio_json_file(json_file);
+  });
+
+  let lasio_json_str = wellio.read_lasio_json_file(json_file);
+  let lasio_obj = JSON.parse(lasio_json_str);
+  let wellio_obj = wellio.lasio_obj_2_wellio_obj(lasio_obj);
+
+  t.equal(wellio_obj["VERSION INFORMATION"].VERS.DATA, 2,
+    "Sample json: LAS is version 2"
+  );
+
+  t.end();
+});

--- a/dist/test/read_las_json/test_read_lasio_sample_2.0_empty_headers.js
+++ b/dist/test/read_las_json/test_read_lasio_sample_2.0_empty_headers.js
@@ -4,9 +4,9 @@ const wellio = require('../../index.js');
 /**
 * A test function for v2 empty headers
 */
-test('readLasioJson: test_read_v2_sample_empty_headers', function(t) {
+test('readLasioJson: test_read_lasio_sample_2.0_with_empty_headers.json', function(t) {
   t.plan(2);
-  json_file = "assets/json_files/sample_2.0_empty_headers.json";
+  json_file = "assets/json_files/lasio_sample_2.0_empty_headers.json";
 
   t.doesNotThrow(function() {
     let lasio_json_str = wellio.read_lasio_json_file(json_file);

--- a/dist/test/read_las_json/test_read_lasio_sample_2.0_pretty.js
+++ b/dist/test/read_las_json/test_read_lasio_sample_2.0_pretty.js
@@ -1,9 +1,9 @@
 const test = require('tape');
 const wellio = require('../../index.js');
 
-test('las2json: test_read_v2_sample', function(t) {
+test('readLasioJson: test_read_lasio_sample_2.0_pretty.json', function(t) {
   t.plan(2);
-  json_file = "assets/json_files/sample_2.0_pretty.json";
+  json_file = "assets/json_files/lasio_sample_2.0_pretty.json";
 
   t.doesNotThrow(function() {
     let lasio_json_str = wellio.read_lasio_json_file(json_file);

--- a/dist/test/read_las_json/test_read_lasio_sample_2.0_with_null.js
+++ b/dist/test/read_las_json/test_read_lasio_sample_2.0_with_null.js
@@ -1,9 +1,9 @@
 const test = require('tape');
 const wellio = require('../../index.js');
 
-test('readLasioJson: test_read_v2_sample', function(t) {
-  t.plan(2);
-  json_file = "assets/json_files/sample_2.0.json";
+test('readLasioJson: test_read_lasio_sample_2.0_null.json', function(t) {
+  t.plan(3);
+  json_file = "assets/json_files/lasio_sample_2.0_null.json";
 
   t.doesNotThrow(function() {
     let lasio_json_str = wellio.read_lasio_json_file(json_file);
@@ -15,6 +15,10 @@ test('readLasioJson: test_read_v2_sample', function(t) {
 
   t.equal(wellio_obj["VERSION INFORMATION"].VERS.DATA, 2,
     "Sample json: LAS is version 2"
+  );
+
+  t.equal(wellio_obj.CURVES.ILD[1], null,
+    "Sample json: LAS null value in CURVES.ILD[1] is null"
   );
 
   t.end();

--- a/dist/test/read_las_json/test_read_wellio_sample_2.0.js
+++ b/dist/test/read_las_json/test_read_wellio_sample_2.0.js
@@ -1,0 +1,20 @@
+const test = require('tape');
+const wellio = require('../../index.js');
+
+test('readWellioJson: test_read_wellio_sample_2.0.json', function(t) {
+  t.plan(2);
+  json_file = "assets/json_files/wellio_sample_2.0.json";
+
+  t.doesNotThrow(function() {
+    let wellio_json_str = wellio.read_lasio_json_file(json_file);
+  });
+
+  let wellio_json_str = wellio.read_lasio_json_file(json_file);
+  let wellio_obj = JSON.parse(wellio_json_str);
+
+  t.equal(wellio_obj["VERSION INFORMATION"].VERS.DATA, '2.0',
+    "Sample Wellio json: LAS is version 2"
+  );
+
+  t.end();
+});

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "dist/test/test.js",
     "test-lasload": "tape dist/test/test_lasload.js",
     "test-las2json": "tape dist/test/las2json/test_*.js",
+    "test-read-lasio-json": "tape dist/test/read_las_json/test_*.js",
     "test-all": "tape dist/test/test*.js"
   },
   "files": [


### PR DESCRIPTION
Resolves #43 

**Fix tests for reading lasio and wellio json files**

The tests run with npm run test-las2json are updated as follows:

* to match current test file names
* to add specific wellio-json tests
* to test that null values are read successfully

**Test restults**
```node
npm run test-read-lasio-json
```
```
> wellio@0.1.7 test-read-lasio-json /usr/local/devel/Apps/node-apps/wellio.js
> tape dist/test/read_las_json/test_*.js

TAP version 13
# readLasioJson: test_read_sample_2.0.json
ok 1 should not throw
ok 2 Sample json: LAS is version 2
# readLasioJson: test_read_lasio_sample_2.0_with_empty_headers.json
ok 3 should not throw
ok 4 Sample json, empty headers: 'VERS' key is not in the Version section
# readLasioJson: test_read_lasio_sample_2.0_pretty.json
ok 5 should not throw
ok 6 Sample pretty json: LAS is version 2
# readLasioJson: test_read_lasio_sample_2.0_null.json
ok 7 should not throw
ok 8 Sample json: LAS is version 2
ok 9 Sample json: LAS null value in CURVES.ILD[1] is null
# readWellioJson: test_read_wellio_sample_2.0.json
ok 10 should not throw
ok 11 Sample Wellio json: LAS is version 2

1..11
# tests 11
# pass  11

# ok
```

Let me know if this needs some additional changes to get approval for merging.

Thank you!,

DC
