### PR TITLE
Iterate demo page header style

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1,3 +1,4 @@
+
 .plot_holder{
 	margin-top: 10px;
 	float:left;
@@ -13,10 +14,6 @@
 	margin: 10px 5px 0 0;
 }
 
-body{
-	margin-left:3%;
-	padding-bottom: 50px;
-}
 
 [hidden] {
   display: none !important;

--- a/index.html
+++ b/index.html
@@ -41,12 +41,12 @@
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js.map"></script>
 </head>
 <body>
-	<div>
-		<h1>Barebones Demo Page for <a href="https://github.com/JustinGOSSES/wellio.js">Wellio.js</a></h1>
+	<div class="jumbotron text-center">
+		<h1><a href="https://github.com/JustinGOSSES/wellio.js">Wellio.js</a></h1>
+		<h2>Demo Page</h2>
+		<h5>Upload local LAS files using a file loader & turn them into json using wellio.js.</h5>
 	</div>
-	<div class="well_step">
-		<h4>Upload local LAS files using a file loader & turn them into json using wellio.js.</h4>
-	</div>
+	<div class="container">
 	<div class="well_step">
 		<p><b>First</b>: use either of these buttons to load a LAS files.</p>
 		<div class="well_pos_relative">
@@ -118,6 +118,7 @@
 			<h3>Download well as JSON file</h3>
 			<button id="download_button" onclick="download_test()" class='btn btn-secondary'>download</button>
 		</div>
+	</div>
 	</div>
 	</br>
 </body>


### PR DESCRIPTION
This pull-request improves the style of the Headers on the index.html.  It puts the main title and header information in a Bootstrap 'jumobotron'.  The spacing could be improved in a follow-up iteration.   Additionally the boarder spacing is changed to use Bootstraps 'container' spacing.

If this change is approved then it could also be implemented for Wellioviz. 

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC