### PR TITLE
Fix parsing for Houston area las files

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -208,7 +208,13 @@ module.exports = {
 			else {
 				unit_and_data_str = unit_and_data.toString()
 			}
-			var unit = unit_and_data_str[0,5].trim();
+
+			// Sometimes the unit_and_data_str are less that 5 chars
+			var last_idx = 5;
+			if ((unit_and_data_str.length - 1) < 5) {
+				last_idx = unit_and_data_str.length - 1;
+			}
+			var unit = unit_and_data_str[0,last_idx].trim();
 			var data = unit_and_data_str.substring(5,unit_and_data_str.length).trim();
 			ver_info_obj["DATA"] = data
 			ver_info_obj["UNIT"] = unit
@@ -231,20 +237,21 @@ module.exports = {
 		for(i = 0; i < param_line_array.length; i++){
 			//// create one object for parameter line
 			//// Skip empty elements and comment elements that start with '#'.
-			if(param_line_array[i] != "" && param_line_array[i][0] !== '#'){
+			if(param_line_array[i] != "" && ! param_line_array[i].trim().startsWith("#")) {
 				var param_obj_inst = splitLineofType1(Object.assign({}, param_info_obj),param_line_array[i]);
 				if (param_obj_inst.MNEM) {
 					lasjson["PARAMETER INFORMATION"][param_obj_inst["MNEM"]] = param_obj_inst;
 				}
 			}
 		}
-		//// Working with CURVE INFORMATION BLOCK second by splitting it by newline into an array.
+		//// Working with CURVE INFORMATION BLOCK second by splitting it by newline
+		//// into an array.
 		//// This skips the line with the section's title.
 		var curve_line_array = curve_info_str.split("\n").slice(1,);
 		for(i = 0; i < curve_line_array.length; i++){
 			//// create one object for parameter line
 			//// Skip empty elements and comment elements that start with '#'.
-			if(curve_line_array[i] != "" && curve_line_array[i][0] !== '#'){
+			if(curve_line_array[i] != "" && ! curve_line_array[i].trim().startsWith("#")) {
 				var curve_obj_inst = splitLineofType1(Object.assign({}, curve_info_obj),curve_line_array[i]);
 				if (curve_obj_inst.MNEM) {
 					lasjson["CURVE INFORMATION BLOCK"][curve_obj_inst["MNEM"]] = curve_obj_inst;
@@ -260,7 +267,7 @@ module.exports = {
 			}
 			//// create one object for parameter line
 			//// Skip empty elements and comment elements that start with '#'.
-			if(well_line_array[i] != "" && well_line_array[i][0] !== '#'){
+			else if(well_line_array[i] != "" && ! well_line_array[i].trim().startsWith("#")) {
 				var well_obj_inst = splitLineofType1(Object.assign({}, well_info_obj),well_line_array[i]);
 				if (well_obj_inst.MNEM) {
 					lasjson["WELL INFORMATION BLOCK"][well_obj_inst["MNEM"]] = well_obj_inst;


### PR DESCRIPTION
#### Description

This pull-request will fix most of the issues with Houston area LAS files.

This is related to JustinGOSSES/wellioviz#115 'USGS LAS logs from Houston area all seem to have a formatting 'error' that makes the trim function fail.'

- Ignore comment lines that would break parsing.
- Handling unit parsing when unit string is less that 5 characters.
- Find Curve names in the CURVE-INFORMATION section when they are not in the ~A.... line.
- Update section parsing in wellio.js to match the current steps in dist/index.js

#### Test Results:

- Manual testing with wellio.js's index.html parse and display curves for a Houston area LAS file.
- All node tests pass  `# pass 37`
- commit f907462 passes GitHub Action for Node CI: https://github.com/dcslagel/wellio.js/actions/runs/391843041

Let me know if this change could be accepted (or rejected) or needs some additional changes to be approved and merged.

DC