### PR TITLE
Exclude LAS files from GitHub Language Stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.las -linguist-detectable 
+*.LAS -linguist-detectable 


### PR DESCRIPTION
#### Description:

This commit updates how GitHub displays Wellio.js's language breakout by
excluding the *.las files which get mis-identified as Lasso files.  See:
https://github.com/github/linguist#detectable

#### Tests:

These are results from running gitHub-linguist on local development machine:
see:
https://github.com/github/linguist#installation

Before this branch:
```
72.14%  Jupyter Notebook
18.64%  Lasso
8.68%   JavaScript
0.28%   CSS
0.25%   HTML
```

After this branch:
```
88.67%  Jupyter Notebook
10.67%  JavaScript
0.35%   CSS
0.31%   HTML
```

Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC