### PR TITLE
Restore download function to main.js

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -204,6 +204,20 @@ function addSingleCurveButton(div_id,curve_name){
 }
 
 
+function download(filename, text) {
+  var element = document.createElement('a');
+  element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
+  element.setAttribute('download', filename);
+
+  element.style.display = 'none';
+  document.body.appendChild(element);
+
+  element.click();
+
+  document.body.removeChild(element);
+}
+
+
 //// function that creates a hidden link that is clicked programatically that uses HTML5 to download the file at that link
 //// the two arguments are the UWI string of the global temp_json object, and a stringified version of the entire wellio json object.
 //// It calls the download() function found in wellio.js JavaScript file.


### PR DESCRIPTION
#### Description:

This pull-request is to resolve issue #66 "looks like download function is missing from main.js in docs folder"

It restores `function download()` to js/main.js.

#### Test Notes:

Tested and Download functionality is restored with this change:

Test:
- open browser to wellio.js/index.html
- upload a las file
- convert it to json
- download the json file to local machine.

--

Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC