### PR TITLE
Update "npm test" to run all tests

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -21,8 +21,6 @@ jobs:
       run: |
         npm ci
         npm run build --if-present
-        npm run test-las2json
-        npm run test-read-lasio-json
-        npm run test-all
+        npm test
       env:
         CI: true

--- a/package.json
+++ b/package.json
@@ -5,11 +5,10 @@
   "main": "dist/index.js",
   "unpkg": "dist/index.js",
   "scripts": {
-    "test": "tape dist/test/test.js",
+    "test": "tape dist/test/test*.js dist/test/read_las_json/test_*.js dist/test/las2json/test_*.js",
     "test-lasload": "tape dist/test/test_lasload.js",
     "test-las2json": "tape dist/test/las2json/test_*.js",
-    "test-read-lasio-json": "tape dist/test/read_las_json/test_*.js",
-    "test-all": "tape dist/test/test*.js"
+    "test-read-lasio-json": "tape dist/test/read_las_json/test_*.js"
   },
   "files": [
     "dist/index.js",


### PR DESCRIPTION
#### Description:

- Add tests to the package.json test script so that it run all the
      current tests: npm test.
- Remove test-all because "npm test" fully replaces it.

```
npm test
...
1..54
# tests 54
# pass  54
```

--

Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC
