### PR TITLE
Handle duplicate headers and changing number of data columns.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -241,17 +241,28 @@ loaded into memory
         }
 
         let counter_of_curve_names = 0;
-        console.warn('curve_data_line_array.length = ', curve_data_line_array.length);
-        console.warn('curve_data_line_array = ', curve_data_line_array);
 
         const last_curv_data_line_position = curve_data_line_array.length - 1;
-        console.warn('curve_data_line_array[last_curv_data_line_position] = ', curve_data_line_array[last_curv_data_line_position]);
 
-        console.warn('curve_data_line_array[last_curv_data_line_position] = ', curve_data_line_array[last_curv_data_line_position]);
-        for (let k = 0; k < curve_data_line_array.length; k++) {
-          if (curve_data_line_array[k] !== '') {
-            lasjson['CURVES'][curve_names_array_holder[counter_of_curve_names]].push(curve_data_line_array[k]);
-            counter_of_curve_names += 1;
+        while (curve_names_array_holder.length < curve_data_line_array.length) {
+          // Data has more columns than the names array.  To fix:
+          // - add addtional generic columns to the previous lasjson['CURVES']
+          //   the row count is in varible 'j'
+          //   popluate the previous rows for the new column with zeros.
+          let col_num = curve_names_array_holder.length + 1
+          let col_name = 'UNKNOWN' + col_num;
+          curve_names_array_holder.push(col_name);
+          lasjson['CURVES'][col_name] = new Array(j).fill('0');
+        }
+
+        // Add row items to CURVES data structure
+        for (let idx in curve_names_array_holder) {
+          if (curve_data_line_array[idx] && curve_data_line_array[idx] !== '') {
+            lasjson['CURVES'][curve_names_array_holder[idx]].push(curve_data_line_array[idx]);
+          }
+          else {
+            // If the item doesn't exist fill its entry with a '0' zero string character
+            lasjson['CURVES'][curve_names_array_holder[idx]].push('0');
           }
         }
         // Zero out curve_data_line_array for next set of data

--- a/dist/test/las2json/test_duplicate_header.js
+++ b/dist/test/las2json/test_duplicate_header.js
@@ -1,0 +1,15 @@
+const test = require('tape');
+const wellio = require('../../index.js');
+
+test('las2json: test_duplicate_header', function(t) {
+  t.plan(3);
+  let well_string = wellio.loadLAS("assets/usgs_bad/260341080252801.19980915.NN.las");
+
+  t.doesNotThrow(function() {
+    let well_json = wellio.las2json(well_string);
+  });
+
+  let well_json = wellio.las2json(well_string);
+  t.ok('DEPT' in well_json.CURVES, "'DEPT' curve header is in CURVES");
+  t.ok('STRT' in well_json['WELL INFORMATION BLOCK'], "'STRT' well header is in WELL");
+});

--- a/dist/test/las2json/test_extra_data_columns.js
+++ b/dist/test/las2json/test_extra_data_columns.js
@@ -1,0 +1,18 @@
+const test = require('tape');
+const wellio = require('../../index.js');
+
+test('las2json: test_extra_data_columns', function(t) {
+  t.plan(6);
+  let well_string = wellio.loadLAS("assets/usgs_bad/261058081145201.19980227.ZE.las");
+
+  t.doesNotThrow(function() {
+    let well_json = wellio.las2json(well_string);
+  });
+
+  let well_json = wellio.las2json(well_string);
+  t.ok('UNKNOWN6' in well_json.CURVES, "'UNKNOWN6' curve header is in CURVES");
+  t.ok('STRT' in well_json['WELL INFORMATION BLOCK'], "'STRT' well header is in WELL");
+  t.equal(well_json.CURVES.UNKNOWN6[0], '0', "Non-existent item in undocumented column IS '0'");
+  t.equal(well_json.CURVES.UNKNOWN6[100], '-30.0', "Entry with a value in the undocumented column");
+  t.equal(well_json.CURVES.UNKNOWN6[356], '0', "Non-existant item after the undocumented column data");
+});


### PR DESCRIPTION
#### Description:

Handle duplicate headers and changing number of data columns.
This pull-request enables parsing some of the LAS files in issue:
- `more malformed LAS files from USGS to handle, mostly florida` #61

Changes to dist/index.js:
- Only read a required unique header and its data once.
  Ignore additional entries for the unique header.
  These are the headers: ~V, ~W, ~C, ~P, ~O, and ~A.
- Move the inital parsing from las string data in interim structured
  section data to sub-function: las2json.readSections()
- Move las2json sub-functions to the bottom of the section to make the
  main logic more prominent.
 - Handle cases of data sections that have an inconsistent number of data
    columns in the data rows. If a row has more data columns than the
    headings, then add generic colunms titled 'UNKNOWN' + a number. Then
    populate the previous rows for that column with zero string values '0'

Add tests: 
- dist/test/las2json/test_duplicate_header.js
- dist/test/las2json/test_extra_data_columns.js

This is a fairly big change, with moving some code sections around and replacing some code with a sub-function. 

#### Test Results:

```
npm run test-las2json
...
1..50
# tests 50
# pass  50
```

--

Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC
